### PR TITLE
fix: correct Unicode output on the BEAM target

### DIFF
--- a/src/Scriptorium.Parchment/Sinks/Universal.fs
+++ b/src/Scriptorium.Parchment/Sinks/Universal.fs
@@ -13,7 +13,14 @@ module Universal =
         #if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT
         emitJsStatement msg "(typeof process !== 'undefined' && process.stdout) ? process.stdout.write($0 + '\\n') : console.log($0)"
         #endif
-        #if !(FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT)
+        #if FABLE_COMPILER_BEAM
+        // Mirrors the stderr branch. Not via Console.WriteLine: fable-library-beam lowers that to
+        // io:format("~s~n"), which writes the UTF-8 binary's raw bytes. That renders correctly only
+        // by accident on a latin1 device; once the device is set to unicode (see Quill's
+        // initTerminal) ~s re-encodes each byte as latin1 and mangles any non-ASCII glyph.
+        Fable.Core.BeamInterop.emitErlStatement msg "io:format(\"~ts~n\", [$0])"
+        #endif
+        #if !(FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT || FABLE_COMPILER_BEAM)
         System.Console.WriteLine(msg)
         #endif
 

--- a/src/Scriptorium.Quill/Prelude.fs
+++ b/src/Scriptorium.Quill/Prelude.fs
@@ -91,3 +91,19 @@ module Prelude =
     #if !(FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT || FABLE_COMPILER_PYTHON || FABLE_COMPILER_BEAM)
         System.Environment.GetEnvironmentVariable("CI") |> isNull |> not
     #endif
+
+    /// Put the terminal into a state where the runner's output renders correctly.
+    /// No-op everywhere except BEAM, where `standard_io` and `standard_error` default to
+    /// latin1 under `erl -noshell`: any codepoint > 255 is then printed as an escape (U+2717
+    /// shows up as an escaped literal instead of ✗) and UTF-8 binaries passed to
+    /// `io:put_chars` are re-encoded as mojibake.
+    /// ANSI colour codes are pure ASCII and so were never affected. The `+pc unicode` VM
+    /// flag does NOT fix this - it only affects printable-list detection in `~p`.
+    let initTerminal () : unit =
+    #if FABLE_COMPILER_BEAM
+        Fable.Core.BeamInterop.emitErlStatement () "io:setopts(standard_io, [{encoding, unicode}])"
+        Fable.Core.BeamInterop.emitErlStatement () "io:setopts(standard_error, [{encoding, unicode}])"
+    #endif
+    #if !FABLE_COMPILER_BEAM
+        ()
+    #endif

--- a/src/Scriptorium.Quill/Quill.fs
+++ b/src/Scriptorium.Quill/Quill.fs
@@ -397,6 +397,7 @@ open Advanced
 type Runner =
 
     static member runTestsWith(configurer: TestConfig -> TestConfig, tests: TestCase list) =
+        initTerminal ()
         let duplicates = findDuplicatePaths tests
 
         if not duplicates.IsEmpty then


### PR DESCRIPTION
Two independent defects made the runner's non-ASCII output wrong on the BEAM target. They have to be fixed **together** — either alone leaves something mangled.

Found while running Quill on the BEAM target from [Fable.Giraffe](https://github.com/dbrattli/Fable.Giraffe).

## Not a colour bug

Worth stating up front, since that was my first guess: colours were never broken on BEAM. ANSI escapes are pure ASCII, so they survive any device encoding, and Ink's `NO_COLOR` gate (`os:getenv("NO_COLOR") =:= false`) was already correct. Verified `NO_COLOR=1` on BEAM still drops colour while keeping bold/dim, as documented.

The bug was Unicode **glyph** encoding.

## 1. `standard_io` / `standard_error` default to latin1

Under `erl -noshell` both devices default to latin1, so any codepoint above 255 prints as an escape instead of the glyph — the failure cross, progress dots and dim dash all came out mangled.

Fixed by `Prelude.initTerminal`, which calls `io:setopts(Device, [{encoding, unicode}])` on both devices and is invoked from `Runner.runTestsWith`. No-op on every other target.

The `+pc unicode` VM flag does *not* fix this — it only affects printable-list detection in `~p`. Confirmed with raw Erlang.

## 2. The stdout sink wrote raw bytes

`Parchment`'s stdout sink had no BEAM branch and fell through to `Console.WriteLine`, which fable-library-beam lowers to `io:format("~s~n")`. `~s` writes the UTF-8 binary's **raw bytes** — correct only by accident on a latin1 device.

So fix 1 alone actually made things worse in a new way: the now-unicode device re-encoded each byte as latin1, flipping the cross from mangled-to-fine and the check from fine-to-`â`. This minimal repro shows the two paths have contradictory encoding contracts:

```
--- default device (latin1) ---
Console.WriteLine: ✓ ✗ · é          <- ok (by accident)
printfn:           (escaped junk)   <- broken

--- device set to unicode ---
Console.WriteLine: â â Â· Ã©          <- broken
printfn:           ✓ ✗ · é          <- ok
```

There is no device setting under which both work. Fixed here by giving stdout an explicit BEAM branch using `~ts`, mirroring what the stderr sink already did — which keeps the fix inside Scriptorium rather than waiting on the compiler.

## Upstream

The `~s` in `console_writeline`/`console_write` is really a fable-library-beam bug; once it's fixed the stdout branch added here becomes redundant (harmless either way). Written up for the Fable repo along with two related `char`-to-string defects, one of which is why Nib's diffs currently report `assertThat 1 (isEqualTo 2)` as `50` vs `49` — that one is **not** fixed here, as the root cause is that BEAM has no distinct runtime representation for `char`.

## Testing

`ink`, `nib`, `parchment` and `quill` all pass on all four targets (dotnet / javascript / py / beam):

| | dotnet | javascript | py | beam |
|---|---|---|---|---|
| ink | 51 | 51 | 51 | 51 |
| nib | 68 | 68 | 68 | 68 |
| parchment | 27 | 27 | 27 | 27 |
| quill | 30 | 30 | 30 | 29 + 1 skipped |

Also verified end-to-end against Fable.Giraffe's BEAM suite: `✓ ✗ · -` all render, and `NO_COLOR` still behaves.

One incidental gotcha worth knowing: a `\x` escape sequence inside an F# doc comment breaks the **Python** target, because Fable copies the comment into a Python docstring where `\x` is an invalid escape. Cost me a red Python suite; the comment is worded to avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)